### PR TITLE
Add automatic issue labels

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -20,43 +20,9 @@ permalink: /contact/
         <header class="special container">
           <span class="icon regular fa-envelope"></span>
           <h2>Get in Touch</h2>
-          <p>Questions, corrections, collaborations — we’d love to hear from you.</p>
-        </header>
-
-        <section class="wrapper style4 special container medium">
-          <div class="content">
-            <form action="mailto:echoia@yourdomain.org" method="post" enctype="text/plain">
-              <div class="row gtr-50">
-                <div class="col-6 col-12-mobile">
-                  <input type="text" name="Name" placeholder="Name" />
-                </div>
-                <div class="col-6 col-12-mobile">
-                  <input type="email" name="Email" placeholder="Email" />
-                </div>
-                <div class="col-12">
-                  <input type="text" name="Subject" placeholder="Subject" />
-                </div>
-                <div class="col-12">
-                  <textarea name="Message" placeholder="Message" rows="7"></textarea>
-                </div>
-                <div class="col-12">
-                  <ul class="buttons">
-                    <li><input type="submit" class="special" value="Send Email" /></li>
-                    <li><input type="reset" value="Clear" /></li>
-                  </ul>
-                </div>
-              </div>
-            </form>
-
-            <hr />
-
-            <p>
-              Prefer GitHub? Open an issue:
+          <p>Submit a GitHub issue to contact the echo-IA Organization:</p>
               <a target="_blank" rel="noopener"
-                 href="https://github.com/echo-ia/echoia-hub/issues/new?title=Contact:%20&body=Your%20message:">echo-ia/echoia-hub issues</a>
-            </p>
-          </div>
-        </section>
+                 href="https://github.com/echo-ia/echoia-hub/issues/new?title=Contact:%20&body=Your%20message:&labels=Contact">echo-ia/echoia-hub issues</a>
       </article>
 
       {% include footer.html %}

--- a/pages/submit.html
+++ b/pages/submit.html
@@ -34,7 +34,7 @@ layout: none
               <p>Open a GitHub issue with this template:</p>
               <ul class="buttons">
                 <li><a class="button" target="_blank" rel="noopener"
-                  href="https://github.com/echo-ia/echoia-hub/issues/new?title=Catalog%20submission:%20&body=**Name**:%0A**Survey**:%0A**Bands**:%0A**Method**:%0A**n_gal**:%0A**z_range**:%0A**PSF corrected**:%0A**DOI/Link**:%0A**License**:%0A**Notes**:">Open Issue</a></li>
+                  href="https://github.com/echo-ia/echoia-hub/issues/new?title=Catalog%20submission:%20&body=**Name**:%0A**Survey**:%0A**Bands**:%0A**Method**:%0A**n_gal**:%0A**z_range**:%0A**PSF corrected**:%0A**DOI/Link**:%0A**License**:%0A**Notes**:&labels=Submission">Open Issue</a></li>
               </ul>
             </section>
           </div>


### PR DESCRIPTION
Edited the catatlog submission and contact issue templates to automatically assign "Submission" and "Contact" labels respectively. Also removed the built-in email structure on the contact page. 